### PR TITLE
Add `removeAllListeners()` Capacitor Plugin Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ SafeArea.getStatusBarHeight().then(({ statusBarHeight }) => {
   console.log(statusBarHeight, 'statusbarHeight');
 });
 
+await SafeArea.removeAllListeners();
+
 // when safe-area changed
-const eventListener = await SafeArea.addListener('safeAreaChanged', data => {
+await SafeArea.addListener('safeAreaChanged', data => {
   const { insets } = data;
   for (const [key, value] of Object.entries(insets)) {
     document.documentElement.style.setProperty(
@@ -54,7 +56,6 @@ const eventListener = await SafeArea.addListener('safeAreaChanged', data => {
     );
   }
 });
-eventListener.remove();
 ```
 
 ## API
@@ -123,6 +124,18 @@ event listener when safe-area changed
 | **`listenerFunc`** | <code>(data: <a href="#safeareainsets">SafeAreaInsets</a>) =&gt; void</code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners(): Promise<void>
+```
+
+Capacitor plugin method to remove all registered listeners
+
+**Returns:** <code>Promise&lt;void&gt;</code>
 
 --------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-plugin-safe-area",
-  "version": "2.0.2",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-plugin-safe-area",
-      "version": "2.0.2",
+      "version": "2.0.5",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^5.0.0",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,27 +1,35 @@
-import type { PluginListenerHandle } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core'
 
 export interface SafeAreaPlugin {
   /**
-   *  get mobile SafeArea info
+   *  Get mobile SafeArea info
    */
-  getSafeAreaInsets(): Promise<SafeAreaInsets>;
+  getSafeAreaInsets (): Promise<SafeAreaInsets>;
+
   /**
-   * get mobile statusbar height
+   * Get mobile statusbar height
    */
-  getStatusBarHeight(): Promise<StatusBarInfo>;
+  getStatusBarHeight (): Promise<StatusBarInfo>;
+
   /**
-   * set navigation bar immersive on Android , not implemented on IOS
+   * Set navigation bar immersive on Android , not implemented on IOS
    */
-  setImmersiveNavigationBar(): Promise<void>;
+  setImmersiveNavigationBar (): Promise<void>;
+
   /**
-   * event listener when safe-area changed
+   * Event listener when safe-area changed
    * @param event
    * @param listenerFunc
    */
-  addListener(
+  addListener (
     event: 'safeAreaChanged',
-    listenerFunc: (data: SafeAreaInsets) => void,
+    listenerFunc: (data: SafeAreaInsets) => void
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
+
+  /**
+   * Capacitor plugin method to remove all created listeners
+   */
+  removeAllListeners (): Promise<void>
 }
 
 interface SafeArea {
@@ -30,6 +38,7 @@ interface SafeArea {
   bottom: number;
   left: number;
 }
+
 export interface SafeAreaInsets {
   insets: SafeArea;
 }


### PR DESCRIPTION
Capacitor provides a method for removing all registered listeners. Added this method to the plugin and updated the docs to reflect this change.

This method should be used if there is the possibility of calling the `addListener` method multiple times. Call it first to remove all listeners, before adding a new one to avoid side effects.