### PR TITLE
Fix usage with Capacitor SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SafeAreaPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "6.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Hello!

I was getting an issue where I could not use SPM in my project because Xcode was complaining about mismatching SPM versions:

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/640869d6-5aa8-4e3c-abd4-08babed569b9" />

So, I have changed it to 6.0.0. This matches what capacitor does with official plugins. It will need to be bumped for Capacitor v7 (breaking change anyways)