### PR TITLE
Fix deprecated proguard-android.txt for AGP 9+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
Replace getDefaultProguardFile('proguard-android.txt') with getDefaultProguardFile('proguard-android-optimize.txt') in android/build.gradle.

proguard-android.txt is no longer supported in AGP 9+ since it includes -dontoptimize, which prevents R8 from performing optimizations. This causes a build failure for projects using Android Gradle Plugin 9.x.